### PR TITLE
CIL-414: external variable openshift_persist_registry

### DIFF
--- a/playbooks/aws/openshift-cluster/tasks/create_security_group.yml
+++ b/playbooks/aws/openshift-cluster/tasks/create_security_group.yml
@@ -6,7 +6,8 @@
 - name: Create security group for ose
   ec2_group:
     name: "{{ security_group }}"
-    description: "{{ security_group }}" 
+    description: "{{ security_group }}"
+    region: "{{ deployment_vars[deployment_type].region }}"
     rules:
       - proto: tcp
         from_port: 80

--- a/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
+++ b/playbooks/aws/openshift-cluster/tasks/launch_instances.yml
@@ -80,6 +80,7 @@
     subnet_id: "{{ deployment_vars[deployment_type].vpc_subnet }}"
     security_groups: "{{ sec_group.group_id }}"
     state: present
+    region: "{{ deployment_vars[deployment_type].region }}"
   register: enis
   with_items: "{{ private_ips }}"
 
@@ -93,6 +94,7 @@
     in_vpc: yes
     reuse_existing_ip_allowed: yes
     state: present
+    region: "{{ deployment_vars[deployment_type].region }}"
   register: eips
   with_items: "{{ enis.results }}"
 
@@ -126,6 +128,7 @@
   ec2_eni:
     eni_id: "{{ item.interface.id }}"
     delete_on_termination: true
+    region: "{{ deployment_vars[deployment_type].region }}"
   with_items: "{{ enis.results }}"
   when: enis.changed == true
 

--- a/playbooks/aws/openshift-cluster/templates/user_data.j2
+++ b/playbooks/aws/openshift-cluster/templates/user_data.j2
@@ -20,3 +20,9 @@ write_files:
   content: |
     Defaults:{{ deployment_vars[deployment_type].ssh_user }} !requiretty
 {% endif %}
+{% if type in ['node'] and sub_host_type in ['infra'] and openshift_persist_registry is defined and openshift_persist_registry | bool %}
+runcmd:
+  - mkdir -p /mnt/registry
+  - chown 1001:root /mnt/registry
+{% endif %}
+

--- a/playbooks/aws/openshift-cluster/terminate.yml
+++ b/playbooks/aws/openshift-cluster/terminate.yml
@@ -40,7 +40,7 @@
         tags:
           environment:   "{{ hostvars[item]['ec2_tag_environment'] }}"
           clusterid:     "{{ hostvars[item]['ec2_tag_clusterid'] }}"
-          host-type:     "{{ hostvars[item]['ec2_tag_host-type'] }}"
+          host-type:     "{{ hostvars[item]['ec2_tag_host_type'] }}"
           sub_host_type: "{{ hostvars[item]['ec2_tag_sub_host_type'] }}"
       with_items: "{{ groups.oo_hosts_to_terminate }}"
       when: "'oo_hosts_to_terminate' in groups"

--- a/playbooks/aws/openshift-cluster/terminate.yml
+++ b/playbooks/aws/openshift-cluster/terminate.yml
@@ -41,7 +41,7 @@
           environment:   "{{ hostvars[item]['ec2_tag_environment'] }}"
           clusterid:     "{{ hostvars[item]['ec2_tag_clusterid'] }}"
           host-type:     "{{ hostvars[item]['ec2_tag_host-type'] }}"
-          sub_host_type: "{{ hostvars[item]['ec2_tag_sub-host-type'] }}"
+          sub_host_type: "{{ hostvars[item]['ec2_tag_sub_host_type'] }}"
       with_items: "{{ groups.oo_hosts_to_terminate }}"
       when: "'oo_hosts_to_terminate' in groups"
 

--- a/playbooks/aws/openshift-cluster/terminate.yml
+++ b/playbooks/aws/openshift-cluster/terminate.yml
@@ -85,6 +85,7 @@
     - name: Remove eip(s)
       ec2_eip:
         state: absent
+        region: "{{ hostvars[item]['ec2_region'] }}"
         ip: "{{ hostvars[item]['ec2_ip_address'] }}"
       with_items: "{{ groups.oo_hosts_to_terminate }}"
       when: "'oo_hosts_to_terminate' in groups"
@@ -123,8 +124,10 @@
       with_items: "{{ ec2_stop.results }}"
       when: ec2_stop | changed
 
-    - name: Remove security group
+    - name: Remove security group (a failure is okay)
+      ignore_errors: yes 
       ec2_group:
         name: "{{ lookup('oo_option', 'ec2_security_groups') | default([ 'public' ], True) }}"
+        region: "{{ hostvars[item]['ec2_region'] }}"
         description: "{{ lookup('oo_option', 'ec2_security_groups') | default([ 'public' ], True) }}"
         state: absent

--- a/playbooks/aws/openshift-cluster/vars.yml
+++ b/playbooks/aws/openshift-cluster/vars.yml
@@ -5,7 +5,7 @@ deployment_rhel7_ent_base:
   # rhel-7.1, requires cloud access subscription
   image: "{{ lookup('oo_option', 'ec2_image') | default('ami-10251c7a', True) }}"
   image_name: "{{ lookup('oo_option', 'ec2_image_name') | default(None, True) }}"
-  region: "{{ lookup('oo_option', 'AWS_REGION') | default('us-east-1', True) }}"
+  region: "{{ lookup('oo_option', 'ec2_region') | default('us-east-1', True) }}"
   ssh_user: ec2-user
   become: yes
   keypair: "{{ lookup('oo_option', 'ec2_keypair') | default('libra', True) }}"
@@ -19,7 +19,7 @@ deployment_vars:
     # centos-7, requires marketplace
     image: "{{ lookup('oo_option', 'ec2_image') | default('ami-6d1c2007', True) }}"
     image_name: "{{ lookup('oo_option', 'ec2_image_name') | default(None, True) }}"
-    region: "{{ lookup('oo_option', 'AWS_REGION') | default('us-east-1', True) }}"
+    region: "{{ lookup('oo_option', 'ec2_region') | default('us-east-1', True) }}"
     ssh_user: centos
     become: yes
     keypair: "{{ lookup('oo_option', 'ec2_keypair') | default('libra', True) }}"

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -311,3 +311,11 @@
     owner: "{{ item }}"
     group: "{{ 'root' if item == 'root' else _ansible_ssh_user_gid.stdout  }}"
   with_items: "{{ client_users }}"
+
+- name: Set up registry on the infra node if openshift_psersist_registry is defined and true step 1 (add registry to scc)
+  command: 'oadm policy add-scc-to-user privileged system:serviceaccount:default:registry'
+  when: openshift_persist_registry is defined and openshift_persist_registry | bool
+
+- name: Set up registry on the infra node if openshift_psersist_registry is defined and true step 2 (create docker-registry with persistent volume definition)
+  command: "oadm registry --service-account=registry --config={{ openshift.common.config_base }}/master/admin.kubeconfig --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' --mount-host=/mnt/registry --selector='type=infra'"
+  when: openshift_persist_registry is defined and openshift_persist_registry | bool


### PR DESCRIPTION
this controls that:
1. ec2 instance userdata for infra nodes optionally creates a directory with the correct permissions via oadm
2. the master set up the registry in scc and  creates/modifies the docker registry pod

This is tested with and without specifying openshift_hosted_manage_registry=false, and works.
