### PR TITLE
The ec2.ini file is configured differently between

### DIFF
--- a/playbooks/aws/openshift-cluster/terminate.yml
+++ b/playbooks/aws/openshift-cluster/terminate.yml
@@ -40,8 +40,8 @@
         tags:
           environment:   "{{ hostvars[item]['ec2_tag_environment'] }}"
           clusterid:     "{{ hostvars[item]['ec2_tag_clusterid'] }}"
-          host-type:     "{{ hostvars[item]['ec2_tag_host_type'] }}"
-          sub_host_type: "{{ hostvars[item]['ec2_tag_sub_host_type'] }}"
+          host-type:     "{{ hostvars[item]['ec2_tag_host-type'] }}"
+          sub_host_type: "{{ hostvars[item]['ec2_tag_sub-host-type'] }}"
       with_items: "{{ groups.oo_hosts_to_terminate }}"
       when: "'oo_hosts_to_terminate' in groups"
 


### PR DESCRIPTION
what comes with the openshift ansible installer and
the one that’s stock with Tower. Without this the termination playbook fails.
